### PR TITLE
Adding individual surface family and user integration surface solution output

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -680,7 +680,7 @@ class ADFLOW(AeroSolver):
             j = self.nSlice + i + 1
 
             if useDir:
-                direction = sliceDir[j]
+                direction = sliceDir[i]
             else:
                 direction = dummySliceDir
 

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -20,6 +20,7 @@ v. 1.0  - Original pyAero Framework Implementation (RP,SM 2008)
 
 import copy
 import hashlib
+
 # =============================================================================
 # Imports
 # =============================================================================
@@ -3107,7 +3108,7 @@ class ADFLOW(AeroSolver):
             f.close()
         # end if (root proc )
 
-    def writeSurfaceASCII(self, familyName, outputDir=None, baseName=None, number=None):
+    def writeBCSurfaceASCII(self, familyName, outputDir=None, baseName=None, number=None):
         if outputDir is None:
             outputDir = self.getOptions("outputDirectory")
 
@@ -3126,8 +3127,9 @@ class ADFLOW(AeroSolver):
         else:
             if self.getOption("numberSolutions"):
                 baseName = f"{baseName}_{familyName.lower()}_{self.curAP.adflowData.callCounter:0{numDigits}d}"
-        
+
         fileName = os.path.join(outputDir, baseName)
+        fileName += ".dat"
 
         self.adflow.tecplotio.writebcsurfacesascii(fileName, famList)
 
@@ -3151,6 +3153,7 @@ class ADFLOW(AeroSolver):
                 baseName = f"{baseName}_{familyName.lower()}_{self.curAP.adflowData.callCounter:0{numDigits}d}"
 
         fileName = os.path.join(outputDir, baseName)
+        fileName += ".dat"
 
         self.adflow.tecplotio.writeuserintsurf(familyName, fileName, famID)
 

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -20,7 +20,6 @@ v. 1.0  - Original pyAero Framework Implementation (RP,SM 2008)
 
 import copy
 import hashlib
-
 # =============================================================================
 # Imports
 # =============================================================================
@@ -3108,6 +3107,30 @@ class ADFLOW(AeroSolver):
             f.close()
         # end if (root proc )
 
+    def writeSurfaceASCII(self, familyName, outputDir=None, baseName=None, number=None):
+        if outputDir is None:
+            outputDir = self.getOptions("outputDirectory")
+
+        if baseName is None:
+            baseName = self.curAP.name
+
+        if not familyName.lower() in self.families:
+            raise Error(f"Family {familyName} is not found in the solver")
+
+        famList = self._getFamilyList(familyName)
+
+        numDigits = self.getOption("writeSolutionDigits")
+
+        if number is not None:
+            baseName = f"{baseName}_{familyName.lower()}_{self.curAP.adflowData.callCounter:0{numDigits}d}"
+        else:
+            if self.getOption("numberSolutions"):
+                baseName = f"{baseName}_{familyName.lower()}_{self.curAP.adflowData.callCounter:0{numDigits}d}"
+        
+        fileName = os.path.join(outputDir, baseName)
+
+        self.adflow.tecplotio.writebcsurfacesascii(fileName, famList)
+
     def writeUserIntSurfFile(self, familyName, outputDir=None, baseName=None, number=None):
         if outputDir is None:
             outputDir = self.getOption("outputDirectory")
@@ -3116,7 +3139,7 @@ class ADFLOW(AeroSolver):
             baseName = self.curAP.name
 
         if not familyName.lower() in self.families:
-            raise Error("Family %s not found in the solver." % familyName)
+            raise Error(f"Family {familyName} not found in the solver.")
 
         famID = self.families[familyName.lower()][0]  # Get the family ID
 

--- a/src/f2py/adflow.pyf
+++ b/src/f2py/adflow.pyf
@@ -646,6 +646,26 @@ python module libadflow
            integer(kind=inttype), optional,intent(in),check(len(famlist)>=nfamlist),depend(famlist) :: nfamlist=len(famlist)
          end subroutine writetecplot
 
+         subroutine writebcsurfacesascii(filename,famlist) ! in output/tecplotIO.F90:tecplotio
+            use constants
+            use communication, only: myid,adflow_comm_world,nproc
+            use inputtimespectral, only: ntimeintervalsspectral
+            use inputphysics, only: equationmode
+            use inputiteration, only: printiterations
+            use inputio, only: precisionsurfgrid,precisionsurfsol
+            use outputmod, only: surfsolnames,numberofsurfsolvariables
+            use surfacefamilies, only: bcfamexchange,famnames,familyexchange
+            use utils, only: echk,setpointers,setbcpointers
+            use bcpointers, only: xx
+            use sorting, only: faminlist
+            use extraoutput, only: surfwriteblank
+            use oversetdata, only: zippermesh,zippermeshes
+            use surfaceutils
+            use petsc
+            character*(*) intent(in) :: filename
+            integer(kind=inttype) dimension(:),intent(in) :: famlist
+         end subroutine writebcsurfacesascii
+
          subroutine initializeliftdistributiondata
          end subroutine initializeliftdistributiondata
 
@@ -686,7 +706,6 @@ python module libadflow
 
          subroutine interpolateintegrationsurfaces
          end subroutine interpolateintegrationsurfaces
-
        end module usersurfaceintegrations
 
        module actuatorregion ! in :test:actuatorDiskRegion.F90

--- a/src/f2py/adflow.pyf
+++ b/src/f2py/adflow.pyf
@@ -648,6 +648,19 @@ python module libadflow
 
          subroutine initializeliftdistributiondata
          end subroutine initializeliftdistributiondata
+
+         subroutine writeuserintsurf(slicename,filename,famid) ! in :test:tecplotIO.F90:tecplotio
+          use constants
+          use inputio
+          use commonformats, only: int5,sci6
+          use usersurfaceintegrationdata, only: userintsurfs,nuserintsurfs,userintsurf
+          use usersurfaceintegrations, only: getusersurfacedata
+          use sorting, only: faminlist
+          character*(*) intent(in) :: slicename
+          character*(*) intent(in) :: filename
+          integer(kind=inttype) intent(in) :: famid
+        end subroutine writeuserintsurf
+
        end subroutine tecplotio
 
        module surfaceintegrations

--- a/src/modules/commonFormats.F90
+++ b/src/modules/commonFormats.F90
@@ -35,4 +35,7 @@ module commonFormats
     ! Integers written with 5 characters
     character(len=maxStringLen) :: int5 = '(*(I5))'
 
+    ! Integers written with 7 characters
+    character(len=maxStringLen) :: int7 = '(*(I7))'
+
 end module commonFormats

--- a/src/output/tecplotIO.F90
+++ b/src/output/tecplotIO.F90
@@ -2487,13 +2487,10 @@ contains
                 open (unit=fileID, file=trim(fname))
 
                 ! Write the title of the file
-                write (fileID, *) "TITLE = ""ADflow Surface Solution Data"""
-
-                ! Integer for FileType: 0 = Full, 1= Grid, 2 = Solution
-                write (fileID, *) ("FILETYPE = FULL")
+                write (fileID, *) "Title = ""ADflow Surface Solution Data"""
 
                 ! Write the variables header
-                write (fileID, "(a)", advance="no") ("VARIABLES = ")
+                write (fileID, "(a)", advance="no") ("Variables = ")
 
                 ! Write the variable names
                 write (fileID, "(a)", advance="no") " ""CoordinateX"" "
@@ -2580,11 +2577,10 @@ contains
                             end do
 
                             if (nCellsToWrite > 0) then
-                                write (fileID, "(1x)")
                                 write (fileID, "(a,a,a)") "Zone T = """, trim(famNames(exch%famList(iFam))), """"
                                 write (fileID, *) "Nodes = ", nNodes, " Elements = ", &
-                                    nCellsToWrite, "ZONETYPE=FEQUADRILATERAL"
-                                write (fileID, *) "DATAPACKING=BLOCK"
+                                    nCellsToWrite, " ZONETYPE=FEQUADRILATERAL"
+                                write (fileID, *) "DATAPACKING=POINT"
 
                             end if
                         end if famInclude


### PR DESCRIPTION
The PR adds capability to write solutions of individual surface families (BCs) and user integration surfaces.

An example of how these are called from pyADflow are:
```python
CFDSolver.writeBCSurfaceASCII("lpc_in", str(output_dir))
CFDSolver.writeBCSurfaceASCII("lpt_out", str(output_dir))
CFDSolver.writeUserIntSurfFile("fan_face", str(output_dir))
CFDSolver.writeUserIntSurfFile("fan_exit", str(output_dir))
```

The interfaces are the same as writing normal Tecplot output:
```python
def writeBCSurfaceASCII(self, familyName, outputDir=None, baseName=None, number=None):
def writeUserIntSurfFile(self, familyName, outputDir=None, baseName=None, number=None):
```